### PR TITLE
Portability fix: use `readlink -f` instead of `realpath`

### DIFF
--- a/etc/service/deployer-github/run
+++ b/etc/service/deployer-github/run
@@ -2,7 +2,7 @@
 set -e
 exec 2>&1
 test `id -u` -gt 0 || exec setuidgid -s deployer-github "$0" "$@"
-sockfile=`realpath "$PWD/server.sock"`
+sockfile=`readlink -f "$PWD/server.sock"`
 cd ./root
 exec unixserver -v "$sockfile" -- \
   sh -c '. "$0" && exec "$@"' /etc/deployer-github.conf \


### PR DESCRIPTION
Looks like `realpath` was introduced into coreutils recently and still might not be in some distros. To boot, there was a `realpath` program prior to the coreutils one, and it has different behavior. Avoid the whole thing.

https://unix.stackexchange.com/a/101559